### PR TITLE
fix: parse_json now also returns owner, name, and sha

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -15,7 +15,7 @@ def webhook():
     if request.method == "POST":
         try:
             data = request.json
-            clone_url, branch = parse_json(data)
+            clone_url, branch, repo_owner, repo_name, commit_sha = parse_json(data)
             return make_response("success", 200)
         except:
             return make_response("fail", 400)

--- a/src/unit_tests.py
+++ b/src/unit_tests.py
@@ -15,13 +15,19 @@ class parse_json_test(TestCase):
     def setUp(self):
         self.expected_clone_url = "https://github.com/jenniferclarsson/test-repo.git"
         self.expected_branch = "main"
+        self.expected_repo_owner = "jenniferclarsson"
+        self.expected_repo_name = "test-repo"
+        self.expected_commit_sha = "f17b9496a4600bdb21171c331e5e88688936be35"
 
     def test_valid_json(self): 
         with open(os.path.join(ROOT_DIR, "src/test_data/valid_input.json")) as json_file:
             valid_input = json.load(json_file)
-        clone_url, branch = parse_json(valid_input)
+        clone_url, branch, repo_owner, repo_name, commit_sha = parse_json(valid_input)
         self.assertEqual(clone_url, self.expected_clone_url)
         self.assertEqual(branch, self.expected_branch)
+        self.assertEqual(repo_owner, self.expected_repo_owner)
+        self.assertEqual(repo_name, self.expected_repo_name)
+        self.assertEqual(commit_sha, self.expected_commit_sha)
     
     def test_invalid_json(self):
         with open(os.path.join(ROOT_DIR, "src/test_data/invalid_input_no_url.json")) as json_file:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -26,7 +26,10 @@ def parse_json(data):
     try:
         clone_url = data["repository"]["clone_url"]
         branch = data["ref"].replace("refs/heads/", "")
-        return clone_url, branch
+        repo_owner = data["repository"]["owner"]["name"]
+        repo_name = data["repository"]["name"]
+        commit_sha = data["after"]
+        return clone_url, branch, repo_owner, repo_name, commit_sha
     except:
         return "invalid json"
 


### PR DESCRIPTION
repo owner, repo name and commit sha is needed to set commit status later. Therefore parse_json now returns them too.